### PR TITLE
Fix: Explicitly set repo URL for gh-pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "bun run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist -r https://github.com/chiesa2k/rdo-smart-report-33.git"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
The `gh-pages -d dist` command was failing with a `Failed to get remote.origin.url` error.

This commit resolves the issue by explicitly providing the repository URL to the `gh-pages` command using the `-r` option. This removes the need for automatic remote detection and ensures the deployment script can reliably push the build artifacts to the correct repository.