### PR TITLE
Fix: Set Vite 'base' config conditionally

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: "/rdo-smart-report-33/",
+  base: mode === 'production' ? "/rdo-smart-report-33/" : "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
The previous hardcoded `base` path for GitHub Pages deployment was causing the local development server (`bun run dev`) to fail with a 404 error.

This commit fixes the issue by making the `base` configuration conditional. It now uses:
- `/` for development mode, allowing the dev server to work correctly.
- `/<repo-name>/` for production mode, ensuring the build for GitHub Pages has the correct asset paths.

This allows both local development and production deployment to function as expected.