### PR TITLE
Fix: Correct React 18 render syntax in PDF generator

### DIFF
--- a/src/services/pdf-generator.tsx
+++ b/src/services/pdf-generator.tsx
@@ -22,13 +22,12 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
   const photoPreviews = await Promise.all(draftData.photos.map(readAsDataURL));
   const root = createRoot(container);
 
-  // Await rendering
-  await new Promise<void>(resolve => {
-      root.render(<RdoPdfTemplate formData={draftData} previewImages={photoPreviews} />, () => {
-          // Increased timeout to ensure all images have time to load and render
-          setTimeout(resolve, 1500);
-      });
-  });
+  // Render the component. The second argument callback is deprecated in React 18.
+  root.render(<RdoPdfTemplate formData={draftData} previewImages={photoPreviews} />);
+
+  // We must await a timeout to allow React to render and the browser to paint/load images
+  // before we attempt to capture it with html2canvas.
+  await new Promise(resolve => setTimeout(resolve, 1500));
 
   const pdf = new jsPDF('p', 'mm', 'a4');
   const templateElement = container.querySelector('#pdf-template') as HTMLElement;


### PR DESCRIPTION
The PDF generation was failing due to an invalid use of the `root.render()` method from React 18. A warning in the console, `Warning: render(...): does not support the second callback argument`, indicated that a deprecated callback pattern was being used.

This commit fixes the issue by removing the unsupported callback from the `root.render()` call. It now correctly calls `render` and then awaits a separate `setTimeout` promise. This ensures the component has time to render before the `html2canvas` capture is initiated, while using the modern, correct syntax for React 18. This should resolve the PDF generation failures.