### PR TITLE
Fix: Disable auto-saving and correct PDF element selectors

### DIFF
--- a/src/components/RDOForm.tsx
+++ b/src/components/RDOForm.tsx
@@ -88,9 +88,9 @@ export const RDOForm = ({ initialData, onSave }: RDOFormProps) => {
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const enhanceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handleSaveDraft = useCallback(async (isAutoSave = false) => {
+  const handleSaveDraft = useCallback(async () => {
     if (!user) {
-      if (!isAutoSave) toast.error("You must be logged in to save a draft.");
+      toast.error("You must be logged in to save a draft.");
       return;
     }
     setIsSaving(true);
@@ -100,35 +100,15 @@ export const RDOForm = ({ initialData, onSave }: RDOFormProps) => {
       if (!formData.id && savedDraft.id) {
         setFormData(prev => ({ ...prev, id: savedDraft.id }));
       }
-      if (!isAutoSave) {
-          toast.success("Draft saved!");
-      }
+      toast.success("Draft saved!");
       onSave(); // Notify parent that a save occurred
     } catch (error) {
-      if (!isAutoSave) toast.error("Failed to save draft.");
+      toast.error("Failed to save draft.");
       console.error(error);
     } finally {
       setIsSaving(false);
     }
   }, [user, formData, onSave]);
-
-  // Auto-save effect
-  useEffect(() => {
-    if (!user) return;
-
-    // Do not save if the form is pristine (e.g., only has the default blank data)
-    if (!formData.reportNumber && !formData.customer && !formData.serviceReport) {
-        return;
-    }
-
-    const handler = setTimeout(() => {
-      handleSaveDraft(true); // isAutoSave = true
-    }, 2500); // Save 2.5 seconds after user stops typing
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [formData, user, handleSaveDraft]);
 
   const handleNewForm = () => {
     handleSaveDraft(); // Save current work first

--- a/src/services/pdf-generator.tsx
+++ b/src/services/pdf-generator.tsx
@@ -30,13 +30,12 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
   await new Promise(resolve => setTimeout(resolve, 1500));
 
   const pdf = new jsPDF('p', 'mm', 'a4');
-  const templateElement = container.querySelector('#pdf-template') as HTMLElement;
-  if (!templateElement) throw new Error("PDF template element not found");
 
-  const headerElement = templateElement.querySelector('#rdo-header') as HTMLElement;
-  const mainContentElement = templateElement.querySelector('#rdo-main-content') as HTMLElement;
-  const signatureElement = templateElement.querySelector('#rdo-signatures') as HTMLElement;
-  const footerElement = templateElement.querySelector('#rdo-footer') as HTMLElement;
+  // Select all parts from the top-level container to ensure they are all found
+  const headerElement = container.querySelector('#rdo-header') as HTMLElement;
+  const mainContentElement = container.querySelector('#rdo-main-content') as HTMLElement;
+  const signatureElement = container.querySelector('#rdo-signatures') as HTMLElement;
+  const footerElement = container.querySelector('#rdo-footer') as HTMLElement;
 
   if (!headerElement || !mainContentElement || !signatureElement || !footerElement) {
     throw new Error("Could not find all required elements in the PDF template.");


### PR DESCRIPTION
This commit addresses two issues reported by the user:
1.  **Disable Auto-Save:** The auto-save feature in `RDOForm.tsx` has been removed by deleting the `useEffect` hook responsible for it. Saving drafts is now a manual-only action, triggered by the 'Save Draft' button, as per the user's request.
2.  **Fix PDF Generation Error:** The PDF generation was failing with a `Could not find all required elements` error. This was caused by incorrect `querySelector` calls in `pdf-generator.tsx`. The selectors have been corrected to query from the root container, ensuring all template parts (header, footer, etc.) are found before rendering the PDF.