### PR TITLE
This commit introduces a new GitHub Actions workflow to automate the …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
…deployment of the site to GitHub Pages.

The previous manual deployment process (`bun run deploy`) was failing due to persistent timeouts, causing the site to be unavailable.

This new workflow:
- Triggers automatically on every push to the `main` branch.
- Builds the Vite application using `bun`.
- Deploys the generated `dist` directory to GitHub Pages.

This ensures that the live site is always up-to-date with the latest changes in the `main` branch and resolves the deployment issue in a robust and automated fashion.