### PR TITLE
Feat: Adjust PDF layout with smaller margins and standard photo ratio

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -15,7 +15,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
 
   return (
     <div className="fixed -left-[9999px] w-[210mm] bg-white text-black" style={{ fontFamily: 'Arial, sans-serif' }}>
-      <div id="pdf-template" className="p-[10mm] space-y-2 text-[8pt]">
+      <div id="pdf-template" className="p-[5mm] space-y-2 text-[8pt]">
 
         {/* Header Section */}
         <div id="rdo-header" className="flex justify-between items-start mb-2">
@@ -147,11 +147,13 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                     <div className="mt-4 grid grid-cols-3 gap-4">
                       {previewImages.map((src, index) => (
                         <div key={index} className="text-center">
-                          <img
-                            src={src}
-                            alt={`Foto ${index + 1}`}
-                            className="w-full h-auto object-contain border border-black"
-                          />
+                          <div className="aspect-[5/4] w-full border border-black">
+                            <img
+                              src={src}
+                              alt={`Foto ${index + 1}`}
+                              className="w-full h-full object-cover"
+                            />
+                          </div>
                           <p className="text-[7pt] font-bold mt-1">Foto {index + 1}</p>
                         </div>
                       ))}
@@ -185,7 +187,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
       </div>
 
       {/* Footer Section */}
-      <div id="rdo-footer" className="absolute bottom-[10mm] left-[10mm] right-[10mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
+      <div id="rdo-footer" className="absolute bottom-[5mm] left-[5mm] right-[5mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
         <div className="flex justify-between text-center">
           <div>
             <p className="font-bold">Headquarter | Rio de Janeiro</p>

--- a/src/services/pdf-generator.tsx
+++ b/src/services/pdf-generator.tsx
@@ -42,7 +42,7 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
 
   const pageWidth = 210;
   const pageHeight = 297;
-  const margin = 10;
+  const margin = 5;
   const contentWidth = pageWidth - (margin * 2);
 
   const toCanvas = (el: HTMLElement) => html2canvas(el, { scale: 2, useCORS: true, allowTaint: true, backgroundColor: null });


### PR DESCRIPTION
This commit implements two layout adjustments to the generated PDF based on user feedback:

1.  **Reduce PDF Margins:** The margins have been further reduced from 10mm to 5mm. This change was applied to both `src/services/pdf-generator.tsx` and `src/components/RdoPdfTemplate.tsx` to ensure the generated PDF has more usable content space.

2.  **Enforce 5x4 Photo Aspect Ratio:** All photos inserted into the report will now be displayed with a standard 5:4 aspect ratio. This is achieved by wrapping the image in a container with `aspect-[5/4]` and using `object-cover` to ensure the image fills the space uniformly, providing a more consistent and professional appearance.