### PR TITLE
Feat: Adjust PDF layout to match reference image

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -15,23 +15,23 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
 
   return (
     <div className="fixed -left-[9999px] w-[210mm] bg-white text-black" style={{ fontFamily: 'Arial, sans-serif' }}>
-      <div id="pdf-template" className="p-[5mm] space-y-2 text-[8pt]">
+      <div id="pdf-template" className="px-[7mm] py-[10mm] space-y-2 text-[8pt]">
 
         {/* Header Section */}
         <div id="rdo-header" className="flex justify-between items-start mb-2">
-          <div className="w-[40mm]">
+          <div className="w-[30mm]">
             <img
               src={`https://i.imgur.com/S1FfyjQ.png`}
               crossOrigin="anonymous"
               alt="Supply Marine"
-              className="h-[15mm] object-contain"
+              className="h-[12mm] object-contain"
             />
           </div>
           <div className="text-center">
             <h1 className="font-bold text-[10pt]">RELATÓRIO DIÁRIO DE OBRA</h1>
             <p className="text-[7pt]">Daily Attendance Report</p>
           </div>
-          <div className="w-[40mm] text-right font-bold">
+          <div className="w-[30mm] text-right font-bold">
             <p>FR - EG - 001</p>
             <p>Rev: 00</p>
           </div>
@@ -187,7 +187,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
       </div>
 
       {/* Footer Section */}
-      <div id="rdo-footer" className="absolute bottom-[5mm] left-[5mm] right-[5mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
+      <div id="rdo-footer" className="absolute bottom-[10mm] left-[7mm] right-[7mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
         <div className="flex justify-between text-center">
           <div>
             <p className="font-bold">Headquarter | Rio de Janeiro</p>

--- a/src/services/pdf-generator.tsx
+++ b/src/services/pdf-generator.tsx
@@ -42,8 +42,9 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
 
   const pageWidth = 210;
   const pageHeight = 297;
-  const margin = 5;
-  const contentWidth = pageWidth - (margin * 2);
+  const marginX = 7;
+  const marginY = 10;
+  const contentWidth = pageWidth - (marginX * 2);
 
   const toCanvas = (el: HTMLElement) => html2canvas(el, { scale: 2, useCORS: true, allowTaint: true, backgroundColor: null });
 
@@ -64,7 +65,7 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
 
   // Legacy behavior: photos are part of the main content canvas
 
-  const availablePageHeight = pageHeight - headerHeight - footerHeight - (margin * 2);
+  const availablePageHeight = pageHeight - headerHeight - footerHeight - (marginY * 2);
 
   let contentProcessedY = 0;
   let pageCount = 0;
@@ -72,7 +73,7 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
   while (contentProcessedY < mainContentTotalHeight) {
     pageCount++;
     pdf.addPage();
-    pdf.addImage(headerImgData, 'PNG', margin, margin, contentWidth, headerHeight);
+    pdf.addImage(headerImgData, 'PNG', marginX, marginY, contentWidth, headerHeight);
 
     const cropY = contentProcessedY;
     const cropHeight = Math.min(mainContentTotalHeight - contentProcessedY, availablePageHeight);
@@ -91,7 +92,7 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
         pageCanvas.width, pageCanvas.height
       );
       const pageImgData = pageCanvas.toDataURL('image/png', 1.0);
-      pdf.addImage(pageImgData, 'PNG', margin, margin + headerHeight, contentWidth, cropHeight);
+      pdf.addImage(pageImgData, 'PNG', marginX, marginY + headerHeight, contentWidth, cropHeight);
     }
 
     contentProcessedY += cropHeight;
@@ -109,11 +110,11 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
   pdf.setPage(pageCount);
 
   if (spaceLeftOnLastPage > signatureHeight + 5) {
-    pdf.addImage(signatureImgData, 'PNG', margin, margin + headerHeight + lastPageContentHeight + 5, contentWidth, signatureHeight);
+    pdf.addImage(signatureImgData, 'PNG', marginX, marginY + headerHeight + lastPageContentHeight + 5, contentWidth, signatureHeight);
   } else {
     pdf.addPage();
-    pdf.addImage(headerImgData, 'PNG', margin, margin, contentWidth, headerHeight);
-    pdf.addImage(signatureImgData, 'PNG', margin, margin + headerHeight + 5, contentWidth, signatureHeight);
+    pdf.addImage(headerImgData, 'PNG', marginX, marginY, contentWidth, headerHeight);
+    pdf.addImage(signatureImgData, 'PNG', marginX, marginY + headerHeight + 5, contentWidth, signatureHeight);
     pdf.addImage(footerImgData, 'PNG', 0, pageHeight - footerHeight, pageWidth, footerHeight);
   }
 


### PR DESCRIPTION
This commit adjusts the PDF layout to match the proportions shown in the user's reference image. The changes include:

1.  **Asymmetrical Margins:** Implemented separate horizontal (7mm) and vertical (10mm) margins to better utilize page space. This was applied in both `src/services/pdf-generator.tsx` and `src/components/RdoPdfTemplate.tsx`.

2.  **Resized Logo:** The header logo has been resized from 15mm to 12mm in height, with its container width adjusted from 40mm to 30mm, to prevent distortion and align with the new layout.