### PR TITLE
Feat: Minimize PDF margins to maximize content area

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -15,7 +15,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
 
   return (
     <div className="fixed -left-[9999px] w-[210mm] bg-white text-black" style={{ fontFamily: 'Arial, sans-serif' }}>
-      <div id="pdf-template" className="px-[7mm] py-[10mm] space-y-2 text-[8pt]">
+      <div id="pdf-template" className="px-[3mm] py-[5mm] space-y-2 text-[8pt]">
 
         {/* Header Section */}
         <div id="rdo-header" className="flex justify-between items-start mb-2">
@@ -187,7 +187,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
       </div>
 
       {/* Footer Section */}
-      <div id="rdo-footer" className="absolute bottom-[10mm] left-[7mm] right-[7mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
+      <div id="rdo-footer" className="absolute bottom-[5mm] left-[3mm] right-[3mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
         <div className="flex justify-between text-center">
           <div>
             <p className="font-bold">Headquarter | Rio de Janeiro</p>

--- a/src/services/pdf-generator.tsx
+++ b/src/services/pdf-generator.tsx
@@ -42,8 +42,8 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
 
   const pageWidth = 210;
   const pageHeight = 297;
-  const marginX = 7;
-  const marginY = 10;
+  const marginX = 3;
+  const marginY = 5;
   const contentWidth = pageWidth - (marginX * 2);
 
   const toCanvas = (el: HTMLElement) => html2canvas(el, { scale: 2, useCORS: true, allowTaint: true, backgroundColor: null });


### PR DESCRIPTION
This commit further reduces the PDF margins to maximize the usable content space, based on user feedback.

The changes include:
- Updating the horizontal margin (`marginX`) to 3mm and the vertical margin (`marginY`) to 5mm in `src/services/pdf-generator.tsx`.
- Adjusting the padding and footer positioning in `src/components/RdoPdfTemplate.tsx` to match the new 3mm horizontal and 5mm vertical margins.