### PR TITLE
Feat: Reduce vertical margins to 3mm

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -15,7 +15,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
 
   return (
     <div className="fixed -left-[9999px] w-[210mm] bg-white text-black" style={{ fontFamily: 'Arial, sans-serif' }}>
-      <div id="pdf-template" className="px-[3mm] py-[5mm] space-y-2 text-[8pt]">
+      <div id="pdf-template" className="px-[3mm] py-[3mm] space-y-2 text-[8pt]">
 
         {/* Header Section */}
         <div id="rdo-header" className="flex justify-between items-start mb-2">
@@ -187,7 +187,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
       </div>
 
       {/* Footer Section */}
-      <div id="rdo-footer" className="absolute bottom-[5mm] left-[3mm] right-[3mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
+      <div id="rdo-footer" className="absolute bottom-[3mm] left-[3mm] right-[3mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
         <div className="flex justify-between text-center">
           <div>
             <p className="font-bold">Headquarter | Rio de Janeiro</p>

--- a/src/services/pdf-generator.tsx
+++ b/src/services/pdf-generator.tsx
@@ -43,7 +43,7 @@ export const generatePdfBlob = async (draftData: RDOFormData): Promise<Blob> => 
   const pageWidth = 210;
   const pageHeight = 297;
   const marginX = 3;
-  const marginY = 5;
+  const marginY = 3;
   const contentWidth = pageWidth - (marginX * 2);
 
   const toCanvas = (el: HTMLElement) => html2canvas(el, { scale: 2, useCORS: true, allowTaint: true, backgroundColor: null });


### PR DESCRIPTION
This commit reduces the vertical PDF margins from 5mm to 3mm to match the horizontal margins, creating a symmetrical layout and maximizing usable content space.

The changes include:
- Updating the `marginY` variable in `src/services/pdf-generator.tsx` from 5 to 3.
- Adjusting the vertical padding and footer positioning in `src/components/RdoPdfTemplate.tsx` to match the new 3mm vertical margin.