### PR TITLE
Fix: Reduce internal vertical padding in Service Report

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -141,7 +141,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
             </thead>
             <tbody>
               <tr>
-                <td colSpan={4} className="border border-black p-2 align-top h-[100mm]">
+                <td colSpan={4} className="border border-black p-1 align-top h-[100mm]">
                   <div className="whitespace-pre-wrap">{val(formData.serviceReport)}</div>
                   {previewImages.length > 0 && (
                     <div className="mt-4 grid grid-cols-3 gap-4">


### PR DESCRIPTION
This commit reduces the internal padding of the "Service Report" text area to create more vertical space for text content, as requested by the user.

The change involves updating the padding class on the table cell containing the service report from `p-2` to `p-1` in `src/components/RdoPdfTemplate.tsx`.