### PR TITLE
Feat: Finalize PDF layout with compact rows and corrected margins

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -15,7 +15,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
 
   return (
     <div className="fixed -left-[9999px] w-[210mm] bg-white text-black" style={{ fontFamily: 'Arial, sans-serif' }}>
-      <div id="pdf-template" className="px-[3mm] py-[3mm] space-y-2 text-[8pt]">
+      <div id="pdf-template" className="space-y-2 text-[8pt]">
 
         {/* Header Section */}
         <div id="rdo-header" className="flex justify-between items-start mb-2">
@@ -47,7 +47,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                 <td className="border border-black p-1">Ordem de Serviço N° / Service Number</td>
                 <td className="border border-black p-1">Horário de Atendimento / Time of Attendance</td>
               </tr>
-              <tr className="text-center h-[8mm]">
+              <tr className="text-center h-[6mm]">
                 <td className="border border-black p-1">{val(formData.reportNumber)}</td>
                 <td className="border border-black p-1">{val(formData.date)}</td>
                 <td className="border border-black p-1">{val(formData.serviceOrderNumber)}</td>
@@ -64,7 +64,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                 <td className="border border-black p-1">Local de Atendimento / Location</td>
                 <td className="border border-black p-1">Solicitante / Requestor</td>
               </tr>
-              <tr className="text-center h-[8mm]">
+              <tr className="text-center h-[6mm]">
                 <td className="border border-black p-1">{val(formData.customer)}</td>
                 <td className="border border-black p-1">{val(formData.vessel)}</td>
                 <td className="border border-black p-1">{val(formData.location)}</td>
@@ -78,7 +78,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
               <tr className="text-center font-bold" style={{ backgroundColor: '#D9E2F3' }}>
                 <td className="border border-black p-1">Objeto / Purpose</td>
               </tr>
-              <tr className="h-[8mm]">
+              <tr className="h-[6mm]">
                 <td className="border border-black p-1">{val(formData.purpose)}</td>
               </tr>
             </tbody>
@@ -92,7 +92,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                 <td className="border border-black p-1">Modelo / Model</td>
                 <td className="border border-black p-1">Serial N°</td>
               </tr>
-              <tr className="text-center h-[8mm]">
+              <tr className="text-center h-[6mm]">
                 <td className="border border-black p-1">{val(formData.equipment)}</td>
                 <td className="border border-black p-1">{val(formData.manufacturer)}</td>
                 <td className="border border-black p-1">{val(formData.model)}</td>
@@ -116,7 +116,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
             </thead>
             <tbody>
               {filledInMembers.map((member, index) => (
-                <tr key={index} className="text-center h-[8mm]">
+                <tr key={index} className="text-center h-[6mm]">
                   <td className="border border-black p-1">{index + 1}.</td>
                   <td className="border border-black p-1">{val(member.register)}</td>
                   <td className="border border-black p-1">{val(member.worker)}</td>
@@ -175,7 +175,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                 <td className="border border-black p-1 w-1/3">Assinatura do Técnico Responsável / Technician's Signature</td>
                 <td className="border border-black p-1 w-1/3">Serviço Concluído à Satisfação / Service Concluded Accordingly</td>
               </tr>
-              <tr className="text-center h-[12mm]">
+              <tr className="text-center h-[10mm]">
                 <td className="border border-black p-1">{val(formData.finalLocation)}</td>
                 <td className="border border-black p-1">{val(formData.technicianSignature)}</td>
                 <td className="border border-black p-1"></td>
@@ -187,7 +187,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
       </div>
 
       {/* Footer Section */}
-      <div id="rdo-footer" className="absolute bottom-[3mm] left-[3mm] right-[3mm] text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
+      <div id="rdo-footer" className="text-[7pt] border-t-2 pt-1" style={{ borderColor: '#8FAADC' }}>
         <div className="flex justify-between text-center">
           <div>
             <p className="font-bold">Headquarter | Rio de Janeiro</p>


### PR DESCRIPTION
This commit implements the final user-requested layout adjustments and fixes critical issues identified during code review.

The changes include:
1.  **Further Reduced Row Height:** The height of all main data table rows has been reduced from 8mm to 6mm, and the signature block from 12mm to 10mm, to make the layout even more compact.

2.  **Fixed Double Margins:** Removed the redundant `px` and `py` padding from the main template container in `RdoPdfTemplate.tsx`. All page margins are now controlled exclusively by the `pdf-generator.tsx` service, preventing layout inconsistencies.

3.  **Fixed Footer Positioning:** Removed absolute positioning from the footer in `RdoPdfTemplate.tsx`. The PDF generator now correctly handles the placement of the footer on each page, resolving potential overlaps.