### PR TITLE
Feat: Adjust logo width for better proportion

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -19,7 +19,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
 
         {/* Header Section */}
         <div id="rdo-header" className="flex justify-between items-start mb-2">
-          <div className="w-[40mm]">
+          <div className="w-[50mm]">
             <img
               src={`https://i.imgur.com/S1FfyjQ.png`}
               crossOrigin="anonymous"


### PR DESCRIPTION
This commit adjusts the PDF header logo to correct its aspect ratio by giving it more horizontal space, as requested by the user.

The change involves increasing the width of the logo's container from 40mm to 50mm in `src/components/RdoPdfTemplate.tsx`. This allows the logo to render at its correct proportions within the header.