### PR TITLE
Feat: Implement smart page-break logic for unbreakable content

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -37,8 +37,8 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
           </div>
         </div>
 
-        {/* Main Content Section */}
-        <div id="rdo-main-content">
+        {/* Main Content Section - Flowable */}
+        <div id="rdo-flowable-content">
           <table className="w-full border-collapse border border-black">
             <tbody>
               <tr className="text-center font-bold" style={{ backgroundColor: '#D9E2F3' }}>
@@ -126,7 +126,10 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
               ))}
             </tbody>
           </table>
+        </div>
 
+        {/* Unbreakable Content Section */}
+        <div id="rdo-unbreakable-content">
           <table className="w-full border-collapse border border-black mt-2">
             <thead>
               <tr className="text-center font-bold" style={{ backgroundColor: '#D9E2F3' }}>
@@ -163,25 +166,24 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
               </tr>
             </tbody>
           </table>
-          
-        </div>
 
-        {/* Signatures Section */}
-        <div id="rdo-signatures" className="pt-2">
-          <table className="w-full border-collapse border border-black">
-            <tbody>
-              <tr className="text-center font-bold" style={{ backgroundColor: '#D9E2F3' }}>
-                <td className="border border-black p-1 w-1/3">Local e Data / Location and Date</td>
-                <td className="border border-black p-1 w-1/3">Assinatura do Técnico Responsável / Technician's Signature</td>
-                <td className="border border-black p-1 w-1/3">Serviço Concluído à Satisfação / Service Concluded Accordingly</td>
-              </tr>
-              <tr className="text-center h-[10mm]">
-                <td className="border border-black p-1">{val(formData.finalLocation)}</td>
-                <td className="border border-black p-1">{val(formData.technicianSignature)}</td>
-                <td className="border border-black p-1"></td>
-              </tr>
-            </tbody>
-          </table>
+          {/* Signatures Section */}
+          <div id="rdo-signatures" className="pt-2">
+            <table className="w-full border-collapse border border-black mt-2">
+              <tbody>
+                <tr className="text-center font-bold" style={{ backgroundColor: '#D9E2F3' }}>
+                  <td className="border border-black p-1 w-1/3">Local e Data / Location and Date</td>
+                  <td className="border border-black p-1 w-1/3">Assinatura do Técnico Responsável / Technician's Signature</td>
+                  <td className="border border-black p-1 w-1/3">Serviço Concluído à Satisfação / Service Concluded Accordingly</td>
+                </tr>
+                <tr className="text-center h-[10mm]">
+                  <td className="border border-black p-1">{val(formData.finalLocation)}</td>
+                  <td className="border border-black p-1">{val(formData.technicianSignature)}</td>
+                  <td className="border border-black p-1"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
This commit refactors the PDF generation process to correctly handle page breaks and prevent specific content blocks from being split. This was necessary because the `html2canvas` library does not respect CSS `break-inside` properties.

The new implementation:
1.  Restructures the HTML template (`RdoPdfTemplate.tsx`) to separate content into a "flowable" block and an "unbreakable" block (containing the service report, images, and signatures).
2.  Updates the PDF generator (`pdf-generator.tsx`) to use a new, more robust logic:
    - It first renders and paginates all the flowable content.
    - It then measures the height of the unbreakable block.
    - If the unbreakable block fits in the remaining space on the last page, it is placed there.
    - If it does not fit, a new page is created for the entire block.

This ensures the user's requirement of keeping the signature and image block together is met reliably.