### PR TITLE
Feat: Reduce image size to save vertical space

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -147,7 +147,7 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                     {previewImages.length > 0 && (
                       <div className="mt-4 flex flex-wrap justify-around">
                         {previewImages.map((src, index) => (
-                          <div key={index} className="text-center p-1" style={{ maxWidth: '32%' }}>
+                          <div key={index} className="text-center p-1" style={{ maxWidth: '28%' }}>
                             <img
                               src={src}
                               alt={`Foto ${index + 1}`}


### PR DESCRIPTION
This commit adjusts the styling of the images in the generated PDF to make them smaller and more compact, as requested by the user.

The change involves reducing the `max-width` of each image's container from 32% to 28% in `src/components/RdoPdfTemplate.tsx`. Since the height is set to auto, this proportionally reduces the height of each image, saving vertical space in the final report while maintaining the responsive three-column layout.