### PR TITLE
Feat: Set a max-height for images to reduce vertical space

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -147,11 +147,12 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                     {previewImages.length > 0 && (
                       <div className="mt-4 flex flex-wrap justify-around">
                         {previewImages.map((src, index) => (
-                          <div key={index} className="text-center p-1" style={{ maxWidth: '28%' }}>
+                          <div key={index} className="text-center p-1" style={{ maxWidth: '32%' }}>
                             <img
                               src={src}
                               alt={`Foto ${index + 1}`}
                               className="w-full h-auto border border-black"
+                              style={{ maxHeight: '40mm' }}
                             />
                             <p className="text-[7pt] font-bold mt-1">Foto {index + 1}</p>
                           </div>


### PR DESCRIPTION
This commit adjusts the styling of the images in the generated PDF to make them smaller and more compact by directly limiting their vertical size.

The change involves adding a `max-height` of `40mm` to each image's `img` tag in `src/components/RdoPdfTemplate.tsx`. This directly constrains the image height while `h-auto` and `w-full` within the flex container ensure the aspect ratio is preserved. This is a more direct approach to controlling the image size as requested by the user.