### PR TITLE
Fix: Revert image sizing to previous proportions

### DIFF
--- a/src/components/RdoPdfTemplate.tsx
+++ b/src/components/RdoPdfTemplate.tsx
@@ -152,7 +152,6 @@ export const RdoPdfTemplate = ({ formData, previewImages }: RdoPdfTemplateProps)
                               src={src}
                               alt={`Foto ${index + 1}`}
                               className="w-full h-auto border border-black"
-                              style={{ maxHeight: '40mm' }}
                             />
                             <p className="text-[7pt] font-bold mt-1">Foto {index + 1}</p>
                           </div>


### PR DESCRIPTION
This commit reverts the previous change that set a fixed `max-height` on the images in the PDF report.

The change removes the `max-height` style from the `img` tag in `src/components/RdoPdfTemplate.tsx`, restoring the behavior where the image height is determined automatically by the container's width. This addresses the user's feedback that the previous adjustment was incorrect.